### PR TITLE
Add configurable Plex streaming Android app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/build/
+/app/build/
+/local.properties
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# glass-plex
-# glass-plex
+# Glass Plex
+
+An experimental Android application for browsing and streaming media from a Plex server.
+
+## Building
+
+The project uses Gradle with the Android plugin. You can build from the command line:
+
+```bash
+gradle build
+```
+
+Or open the project in Android Studio and run it on a device or emulator.
+
+## Configuring Plex
+
+Two pieces of information are required to stream from your Plex Media Server:
+
+1. **Server address** – Update `SERVER_BASE` in [`PlexConfig.kt`](app/src/main/java/com/example/glassplex/PlexConfig.kt) to the base URL of your Plex server (for example `http://192.168.1.10:32400`).
+2. **Authentication token** – In [`MainActivity.kt`](app/src/main/java/com/example/glassplex/ui/MainActivity.kt) replace the `"YOUR_PLEX_TOKEN"` placeholder with a valid Plex token or implement the PIN flow in `PlexAuth.kt` to retrieve one.
+
+After these values are set, running the app will allow you to browse your libraries and tap a poster to start playback using ExoPlayer.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
 }
 android {
     namespace 'com.example.glassplex'

--- a/app/src/main/java/com/example/glassplex/App.kt
+++ b/app/src/main/java/com/example/glassplex/App.kt
@@ -1,6 +1,7 @@
 package com.example.glassplex
 
 import android.app.Application
+import com.example.glassplex.PlexConfig
 import com.example.glassplex.plex.PlexServerApi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -18,7 +19,7 @@ class App: Application() {
         val log = HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BASIC }
         OkHttpClient.Builder().addInterceptor(log).build()
       }
-      single { "http://192.168.1.10:32400" } // TODO: make editable in Settings
+      single { PlexConfig.SERVER_BASE } // TODO: make editable in Settings
       single {
         Retrofit.Builder()
           .baseUrl(get<String>())

--- a/app/src/main/java/com/example/glassplex/PlexConfig.kt
+++ b/app/src/main/java/com/example/glassplex/PlexConfig.kt
@@ -1,0 +1,9 @@
+package com.example.glassplex
+
+object PlexConfig {
+    /**
+     * Base URL to your Plex Media Server.
+     * Replace the default value with the address of your server, e.g. `http://192.168.1.10:32400`.
+     */
+    const val SERVER_BASE = "http://192.168.1.10:32400"
+}

--- a/app/src/main/java/com/example/glassplex/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/glassplex/ui/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.MaterialTheme
@@ -17,8 +18,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.platform.LocalContext
+import android.content.Intent
 import coil.compose.AsyncImage
 import com.example.glassplex.plex.*
+import com.example.glassplex.PlexConfig
+import com.example.glassplex.ui.player.PlayerActivity
 import org.koin.android.ext.android.inject
 import androidx.compose.foundation.lazy.LazyRow
 
@@ -70,9 +75,15 @@ fun RowSection(title: String, videos: List<Video>, token: String) {
 
 @Composable
 fun PosterCard(video: Video, token: String) {
-  val server = "http://192.168.1.10:32400" // TODO: from settings
+  val server = PlexConfig.SERVER_BASE // TODO: from settings
   val poster = posterUrl(server, video.thumb, token)
-  Column(Modifier.width(160.dp)) {
+  val stream = streamUrlHls(server, video.ratingKey, token)
+  val ctx = LocalContext.current
+  Column(
+    Modifier.width(160.dp).clickable {
+      ctx.startActivity(Intent(ctx, PlayerActivity::class.java).putExtra("STREAM_URL", stream))
+    }
+  ) {
     Box(Modifier.height(90.dp)) {
       AsyncImage(
         model = poster,
@@ -87,7 +98,7 @@ fun PosterCard(video: Video, token: String) {
 @Composable
 fun HeroCard(video: Video?, token: String) {
   if (video == null) return
-  val server = "http://192.168.1.10:32400" // TODO: from settings
+  val server = PlexConfig.SERVER_BASE // TODO: from settings
   val art = posterUrl(server, video.art ?: video.thumb, token)
   Box(Modifier.fillMaxWidth().height(160.dp)) {
     AsyncImage(

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
     id 'com.android.application' version '8.5.2' apply false
     id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version '2.0.0' apply false
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,10 @@
+pluginManagement {
+  repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
+
 rootProject.name = 'GlassPlex'
 include ':app'


### PR DESCRIPTION
## Summary
- Introduce a central `PlexConfig` to set the Plex server address
- Enable poster taps to start `PlayerActivity` for streaming via ExoPlayer
- Document build instructions and how to set server and token for Plex

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd18469308327affbeb4192e20264