### PR TITLE
Fix Android plugin version reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.android.application' version '8.5.2' apply false
+    id 'com.android.application' version '8.5.0' apply false
     id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
     id 'org.jetbrains.kotlin.plugin.compose' version '2.0.0' apply false
 }


### PR DESCRIPTION
## Summary
- correct Android Gradle plugin version to 8.5.0

## Testing
- `gradle tasks --no-daemon --console=plain | head -n 200`
- `gradle test --no-daemon --console=plain | head -n 200` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd8d81d08832789c76ce81805f9db