### PR TITLE
Configure dependency repositories

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,5 +6,13 @@ pluginManagement {
   }
 }
 
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+  }
+}
+
 rootProject.name = 'GlassPlex'
 include ':app'


### PR DESCRIPTION
## Summary
- Configure dependencyResolutionManagement to use Google and Maven Central repositories.

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fdbc5f22883279b8331ef4603401a