### PR TITLE
Enable AndroidX

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
## Summary
- enable AndroidX by adding `android.useAndroidX=true`

## Testing
- `gradle test` *(fails: Could not determine the dependencies of task ':app:testDebugUnitTest'. SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff476d4a883278149399dbe898654